### PR TITLE
增加spring.profiles.active启动参数来选择环境

### DIFF
--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultServerProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultServerProvider.java
@@ -104,6 +104,9 @@ public class DefaultServerProvider implements ServerProvider {
   private void initEnvType() {
     // 1. Try to get environment from JVM system property
     m_env = System.getProperty("env");
+    if (Utils.isBlank(m_env)) {
+      m_env = System.getProperty("spring.profiles.active");
+    }
     if (!Utils.isBlank(m_env)) {
       m_env = m_env.trim();
       logger.info("Environment is set to [{}] by JVM system property 'env'.", m_env);


### PR DESCRIPTION
如果公司原有项目在jenkins里已经配置了启动脚本，改用-Denv需要修改很多地方，而在机器上加server.properties来指定对机器环境限制太大，增加spring.profiles.active可以减少客户端配置工作，同时不影响-Denv的指定方式。